### PR TITLE
Send logs through Envoy

### DIFF
--- a/dev_tooling/docker-compose.yml
+++ b/dev_tooling/docker-compose.yml
@@ -56,8 +56,15 @@ services:
   otel-collector:
     image: affirm-otelcol:0.0.7
     container_name: otel-collector
+    deploy:
+      resources:
+        limits:
+          cpus: 0.1
+          memory: 512M
+
     ports:
       - "4317:4317"    # gRPC receiver for OTLP
+      - "8888:8888"
       - "55680:55680"  # OpenTelemetry receiver for traces
     volumes:
       - ${USER_HOME}/workspace/access_log_sampling/dev_tooling/otel-config.yaml:/etc/otel-config.yaml:cached

--- a/dev_tooling/envoy.yaml
+++ b/dev_tooling/envoy.yaml
@@ -47,9 +47,12 @@ static_resources:
                             cluster_name: otel_cluster
                       attributes:
                         values:
-                          key: sampling_rate
-                          value: 
-                            string_value: "%REQ(LATENCY_SAMPLING_RATE)%"
+                          - key: content_type
+                            value: 
+                              string_value: "application/json"
+                          - key: x_affirm_endpoint_name
+                            value:
+                              string_value: "dummy-header"
                           
                           
                           
@@ -94,7 +97,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: "host.docker.internal"
+                      address: otel-collector
                       port_value: 4317
       health_checks:  # Add health check configuration here
         - timeout: 1s

--- a/dev_tooling/otel-config.yaml
+++ b/dev_tooling/otel-config.yaml
@@ -16,6 +16,9 @@ exporters:
   debug:
 
 service:
+  telemetry:
+    metrics:
+      address: '0.0.0.0:8888'
   pipelines:
     logs:
       receivers: [otlp]


### PR DESCRIPTION
These changes allow the environment to send logs through Envoy and have them successfully processed through the collector.