### PR TITLE
Make local webservers simulate our production endpoints

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     lsb-release \
     kafkacat \
+    siege \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the Docker CLI
@@ -21,13 +22,14 @@ RUN curl -L "https://github.com/docker/compose/releases/download/v2.20.2/docker-
 
 # Install the OpenTelemetry Collector Builder (ocb) & Go debugger
 RUN curl --proto '=https' --tlsv1.2 -fL -o /tmp/ocb \
-    https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv0.115.0/ocb_0.115.0_linux_amd64 && \
+    https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv0.118.0/ocb_0.118.0_linux_amd64 && \
     chmod +x /tmp/ocb && \
-    mv /tmp/ocb /usr/local/bin/ocb &&\
-    go install github.com/go-delve/delve/cmd/dlv@latest &&\
-    go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@v0.115.0 &&\
-    go install golang.org/x/tools/cmd/goimports@latest \
-    go install -v golang.org/x/tools/gopls@latest
+    mv /tmp/ocb /usr/local/bin/ocb
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest &&\
+    go install github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen@latest &&\
+    go install golang.org/x/tools/cmd/goimports@latest &&\
+    go install golang.org/x/tools/gopls@latest
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,9 @@ read-kafka-current:
 
 .PHONY: load-test
 test-envoy:
-	while true; do curl -s http://localhost:8080/nginx > /dev/null ; done
+# change this to use siege to test the envoy proxy
+	@echo "Running load test..."
+	siege -c 10 -t 30s -v -f /workspaces/access_log_sampling/dev_tooling/urls.txt 
 
 # Clean up build artifacts
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables
 COLLECTOR_NAME := affirm-otelcol
-DOCKER_IMAGE := affirm-otelcol:0.0.11
+DOCKER_IMAGE := affirm-otelcol:0.0.12
 DOCKERFILE := Dockerfile
 BUILD_DIR := ./affirm-otelcol
 

--- a/dev_tooling/docker-compose.yml
+++ b/dev_tooling/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   otel-collector:
-    image: affirm-otelcol:0.0.11
+    image: affirm-otelcol:0.0.12
     container_name: otel-collector
     deploy:
       resources:

--- a/dev_tooling/envoy.yaml
+++ b/dev_tooling/envoy.yaml
@@ -17,13 +17,29 @@ static_resources:
                     - name: backend
                       domains: ["*"]
                       routes:
-                        - match: { prefix: "/nginx" }
+                        # 5,597,308,284 requests/month
+                        - match: { prefix: "/amplify/digital_wallet_service/should_allow_add_to_wallet" }
                           route:
                             cluster: nginx_service
                             prefix_rewrite: "/"
-                        - match: { prefix: "/apache" }
+                        # 2,866,485 requests/month
+                        - match: { prefix: "/amplify/v1/crm/users/<user_ari>/fraud_unsuspend" }
                           route:
                             cluster: apache_service
+                            prefix_rewrite: "/"
+                        # 445,003 requests/month
+                        - match: { prefix: "/amplify/v1/activities/" }
+                          route:
+                            cluster: nginx_service
+                            prefix_rewrite: "/"
+                        # 2,521 requests/month
+                        - match: { prefix: "/alm/internal/v1/scenarios/update" }
+                          route:
+                            cluster: apache_service
+                            prefix_rewrite: "/"
+                        - match: { prefix: "/no/match" }
+                          route:
+                            cluster: nginx_service
                             prefix_rewrite: "/"
 
                 http_filters:

--- a/dev_tooling/otel-config.yaml
+++ b/dev_tooling/otel-config.yaml
@@ -25,4 +25,4 @@ service:
     logs:
       receivers: [otlp]
       processors: [batch, volumebasedlogsampler]
-      exporters: [debug]
+      exporters: [debug, kafka]

--- a/dev_tooling/urls.txt
+++ b/dev_tooling/urls.txt
@@ -1,2 +1,6 @@
-http://localhost:8080/nginx
-http://localhost:8080/apache
+http://localhost:8080/amplify/digital_wallet_service/should_allow_add_to_wallet
+http://localhost:8080/amplify/v1/crm/users/<user_ari>/fraud_unsuspend
+http://localhost:8080/amplify/v1/activities/
+http://localhost:8080/alm/internal/v1/scenarios/update
+http://localhost:8080/no/match
+http://localhost:8080/fuzz/test

--- a/volumebasedlogsampler/sampling-data.go
+++ b/volumebasedlogsampler/sampling-data.go
@@ -137,14 +137,12 @@ func (volBLogProc *volumeBasedLogSamplerProcessor) buildSamplingRateTable(data [
 	for key := range exclusions {
 		newRates[key] = 1.0
 	}
-	// for testing purposes
-	newRates["/nginx"] = 0.5
 	return newRates
 }
 
 // executePrometheusQuery sends a Prometheus query and parses the response.
 func executePrometheusQuery(apiURL, query, token string) ([]map[string]interface{}, error) {
-	client := &http.Client{Timeout: 90 * time.Second}
+	client := &http.Client{Timeout: 120 * time.Second}
 	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)


### PR DESCRIPTION
1. Set up the Envoy proxy to have the nginx and apache webserver mimic our production endpoints
2. Remove the dummy nginx entry from the sampling table
3. Increase the timeout on Chronosphere from 90s to 120s
4. Version bump
5. Add siege to easily test multiple paths.