### PR TITLE
OBSERVE-2845 Implement various fixes from live stage testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ USER ${USER_UID}:${USER_GID}
 
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY bin/affirm-otelcol /
+# This is a temporary solution until we have the slo.yaml file in an s3 bucket 
+# that we pull initially and poll periodically for updates. 
+# This mounting should be removed when that is available.
 COPY dev_tooling/slo.yaml /
 EXPOSE 4317 55680 55679 8888
 ENTRYPOINT ["/affirm-otelcol"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ USER ${USER_UID}:${USER_GID}
 
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY bin/affirm-otelcol /
-EXPOSE 4317 55680 55679
+COPY dev_tooling/slo.yaml /
+EXPOSE 4317 55680 55679 8888
 ENTRYPOINT ["/affirm-otelcol"]
 CMD ["--config", "/etc/otel/config.yaml"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables
 COLLECTOR_NAME := affirm-otelcol
-DOCKER_IMAGE := affirm-otelcol:0.0.12-alpha-1
+DOCKER_IMAGE := affirm-otelcol:0.0.13
 DOCKERFILE := Dockerfile
 BUILD_DIR := ./affirm-otelcol
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables
 COLLECTOR_NAME := affirm-otelcol
-DOCKER_IMAGE := affirm-otelcol:0.0.13
+DOCKER_IMAGE := affirm-otelcol:0.0.14
 DOCKERFILE := Dockerfile
 BUILD_DIR := ./affirm-otelcol
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables
 COLLECTOR_NAME := affirm-otelcol
-DOCKER_IMAGE := affirm-otelcol:0.0.14
+DOCKER_IMAGE := affirm-otelcol:0.0.15
 DOCKERFILE := Dockerfile
 BUILD_DIR := ./affirm-otelcol
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables
 COLLECTOR_NAME := affirm-otelcol
-DOCKER_IMAGE := affirm-otelcol:0.0.12
+DOCKER_IMAGE := affirm-otelcol:0.0.12-alpha-1
 DOCKERFILE := Dockerfile
 BUILD_DIR := ./affirm-otelcol
 
@@ -15,6 +15,8 @@ TELEMETRYGEN := /go/bin/telemetrygen
 # Default target: Build the entire project
 all: collector binary image
 
+all_amd64: collector binary_amd64 image
+
 # Build the OpenTelemetry Collector components using ocb
 collector:
 	@echo "Building OpenTelemetry Collector components..."
@@ -26,15 +28,22 @@ binary:
 	@echo "Building the binary..."
 	cd $(BUILD_DIR) && CGO_ENABLED=0 $(GO) build -o ../bin
 
+# Build binary for running in k8s
+binary_amd64:
+	@echo "Building the binary..."
+	cd $(BUILD_DIR) && CGO_ENABLED=0 GOARCH=amd64 GOOS=linux $(GO) build -o ../bin
+
 # Build the Docker image
 image:
 	@echo "Building the Docker image..."
 	$(DOCKER) build -t $(DOCKER_IMAGE) -f $(DOCKERFILE) .
 
+# Run collector with volume sampler config
 run:
 	@echo "Running binary..."
 	./bin/$(COLLECTOR_NAME) --config ./dev_tooling/volume-sampler-otel-config.yaml
 
+# Run collector with SLO metrics config
 run_slo:
 	@echo "Running binary..."
 	./bin/$(COLLECTOR_NAME) --config ./dev_tooling/slo-metrics-otel-config.yaml
@@ -61,16 +70,16 @@ gen-logs:
 gen-slo-logs:
 	@echo "Generating SLO-specific log traffic with telemetrygen..."
 	$(TELEMETRYGEN) logs --logs 1 --otlp-insecure --telemetry-attributes content_type=\"http\" \
-	--telemetry-attributes x_affirm_endpoint_name=\"/api/pf/authentication/v1/\" --telemetry-attributes status_code=\"200\" \
+	--telemetry-attributes x_affirm_endpoint_name=\"/api/pf/authentication/v1/\" --telemetry-attributes response_code=\"200\" \
 	--telemetry-attributes method=\"POST\" --telemetry-attributes duration=\"123\"
 	
 	$(TELEMETRYGEN) logs --logs 1 --otlp-insecure --telemetry-attributes content_type=\"http\" \
-	--telemetry-attributes x_affirm_endpoint_name=\"/non-existant\" --telemetry-attributes status_code=\"200\" \
+	--telemetry-attributes x_affirm_endpoint_name=\"/non-existant\" --telemetry-attributes response_code=\"200\" \
 	--telemetry-attributes method=\"POST\" --telemetry-attributes duration=\"123\"
 	
 	$(TELEMETRYGEN) logs --logs 1 --otlp-insecure --telemetry-attributes content_type=\"application/rpc2\" \
 	--telemetry-attributes path=\"/affirm.members.service.apis.api_v1/get_user_locale_v1\" \
-	--telemetry-attributes status_code=\"200\" --telemetry-attributes method=\"POST\" \
+	--telemetry-attributes response_code=\"200\" --telemetry-attributes method=\"POST\" \
 	--telemetry-attributes duration=\"456\"
 
 # Read messages from Kafka topic

--- a/affirm-otelcol/components.go
+++ b/affirm-otelcol/components.go
@@ -13,6 +13,7 @@ import (
 	debugexporter "go.opentelemetry.io/collector/exporter/debugexporter"
 	otlpexporter "go.opentelemetry.io/collector/exporter/otlpexporter"
 	kafkaexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
+	healthcheckextension "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	filterprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor"
 	transformprocessor "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor"
 	batchprocessor "go.opentelemetry.io/collector/processor/batchprocessor"
@@ -26,11 +27,13 @@ func components() (otelcol.Factories, error) {
 	factories := otelcol.Factories{}
 
 	factories.Extensions, err = extension.MakeFactoryMap(
+		healthcheckextension.NewFactory(),
 	)
 	if err != nil {
 		return otelcol.Factories{}, err
 	}
 	factories.ExtensionModules = make(map[component.Type]string, len(factories.Extensions))
+	factories.ExtensionModules[healthcheckextension.NewFactory().Type()] = "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.119.0"
 
 	factories.Receivers, err = receiver.MakeFactoryMap(
 		otlpreceiver.NewFactory(),

--- a/affirm-otelcol/go.mod
+++ b/affirm-otelcol/go.mod
@@ -8,6 +8,7 @@ toolchain go1.22.12
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.119.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.119.0
 	go.opentelemetry.io/collector/component v0.119.0
@@ -104,6 +105,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.119.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.119.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.119.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.119.0 // indirect

--- a/affirm-otelcol/go.sum
+++ b/affirm-otelcol/go.sum
@@ -179,6 +179,10 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.119.0 h1:zQm1CkEuk7HjLNcXQ8WIH1t8WHiJDqIQUMjbTHWRFIY=
 github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.119.0/go.mod h1:6Lo1g1yHyIubBggpk+ify0ORGI7Z0C4xCCpEIzyMXdY=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.119.0 h1:2rJGw7Du16sanQo64b2x6qDh2WkYTIB/k8ztaEp96hA=
+github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.119.0/go.mod h1:lOeos0lj5TR84xGqXbE7jR4VQOOuY+c6YhU9Sk+Xpbc=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.119.0 h1:o1s1koCc7Rg2auZLhFc2Ja6Eo2rOCMHKZJptRwdhoTI=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.119.0/go.mod h1:8rSWjIfW9QDA3KHzdZIfGs+Na0HBEmKg2EMmMplK1X8=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.119.0 h1:3H9R5Ztc4ISphy+bRlHHExqtS04PBYi7Fptwl9XA52M=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.119.0/go.mod h1:txjr7nwuLZUBitwpU4G7EkZ3gyMBfI/4DXMJxX6NAtU=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.119.0 h1:Woc64WQAdBO7EhprsHXKC6zQY+GDtk+Ji3hT1s57Hj8=

--- a/affirm-otelcol/main.go
+++ b/affirm-otelcol/main.go
@@ -20,7 +20,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "affirm-otelcol",
 		Description: "OTEL collector with custom components developped at Affirm",
-		Version:     "0.0.1",
+		Version:     "0.0.13",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/affirm-otelcol/main.go
+++ b/affirm-otelcol/main.go
@@ -20,7 +20,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "affirm-otelcol",
 		Description: "OTEL collector with custom components developped at Affirm",
-		Version:     "0.0.13",
+		Version:     "0.0.14",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/affirm-otelcol/main.go
+++ b/affirm-otelcol/main.go
@@ -20,7 +20,7 @@ func main() {
 	info := component.BuildInfo{
 		Command:     "affirm-otelcol",
 		Description: "OTEL collector with custom components developped at Affirm",
-		Version:     "0.0.14",
+		Version:     "0.0.15",
 	}
 
 	set := otelcol.CollectorSettings{

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -13,6 +13,10 @@ exporters:
   - gomod:
       github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.119.0
 
+extensions:
+  - gomod:
+      github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.119.0
+
 processors:
   - gomod:
       github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.119.0

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   name: affirm-otelcol
   description: OTEL collector with custom components developped at Affirm
   output_path: ./affirm-otelcol
-  version: 0.0.14
+  version: 0.0.15
 
 exporters:
   - gomod:

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   name: affirm-otelcol
   description: OTEL collector with custom components developped at Affirm
   output_path: ./affirm-otelcol
-  version: 0.0.13
+  version: 0.0.14
 
 exporters:
   - gomod:

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   name: affirm-otelcol
   description: OTEL collector with custom components developped at Affirm
   output_path: ./affirm-otelcol
-  version: 0.0.1
+  version: 0.0.13
 
 exporters:
   - gomod:

--- a/dev_tooling/slo.yaml
+++ b/dev_tooling/slo.yaml
@@ -1,4 +1,5 @@
 # Sample file for testing SLO metrics with OpenTelemetry Collector
+# https://docs.google.com/spreadsheets/d/161tMDNJQevB4IBsVBN-SLg2-y5-llizhpUalzbGKflM/edit?gid=991659123#gid=991659123
 slos:
   http:
     POST /api/pf/authentication/v1/:
@@ -66,63 +67,9 @@ slos:
         0.50: 0.723s
         0.99: 1.727s
       success_rate: 99.99
-    # Additional http endpoints per checkout latency SLO program. Needs endpoints
-    # https://docs.google.com/spreadsheets/d/161tMDNJQevB4IBsVBN-SLg2-y5-llizhpUalzbGKflM/edit?gid=991659123#gid=991659123
-    # POST terms_flow_api.edit_email_link:
-    #   latency:
-    #     0.50: 0.206s
-    #     0.99: 1.296s
-    # POST terms_flow_api.initialize_unfreeze_credit_report:
-    #   latency:
-    #     0.50: 0.727s
-    #     0.99: 2.472s
-    # POST terms_flow_api.poll_email_link:
-    #   latency:
-    #     0.50: 0.137s
-    #     0.99: 1.529s
-    # POST terms_flow_api.poll_physical_id:
-    #   latency:
-    #     0.50: N/As
-    #     0.99: N/As
-    # POST terms_flow_api.poll_unfreeze_credit_report:
-    #   latency:
-    #     0.50: 0.599s
-    #     0.99: 2.204s
-    # POST terms_flow_api.resend_email_link:
-    #   latency:
-    #     0.50: 0.314s
-    #     0.99: 1.386s
-    # POST terms_flow_api.resend_sms_link:
-    #   latency:
-    #     0.50: 0.361s
-    #     0.99: 1.631s
-    # POST terms_flow_api.skip_email_link:
-    #   latency:
-    #     0.50: 0.230s
-    #     0.99: 1.609s
-    # POST /api/pf/terms/v1/<flow_ari>/submit_address_confirmation:
-    #   latency:
-    #     0.50: 3.471s
-    #     0.99: 6.666s
-    # POST terms_flow_api.submit_full_ssn_and_address:
-    #   latency:
-    #     0.50: 3.888s
-    #     0.99: 9.487s
-    # POST terms_flow_api.submit_onfido:
-    #   latency:
-    #     0.50: 1.086s
-    #     0.99: 2.006s
-    # POST terms_flow_api.submit_pii_confirmation:
-    #   latency:
-    #     0.50: 1.747s
-    #     0.99: 5.029s
-    # POST terms_flow_api.verify_physical_id:
-    #   latency:
-    #     0.50: N/As
-    #     0.99: N/As
   rpc2:
     /affirm.members.service.apis.api_v1/get_user_locale_v1:
       latency:
         0.5:  0.5s
-        0.99: 0.75s
+        0.99: 1.50s
       success_rate: 99.99

--- a/slometricsemitter/log_processor.go
+++ b/slometricsemitter/log_processor.go
@@ -242,9 +242,6 @@ func (sloMetricsProc *sloMetricsProcessor) getEndpointSLO(endpoint string, metho
 func (sloMetricsProc *sloMetricsProcessor) determineEndpointType(logRecord plog.LogRecord) string {
 	contentType, err := sloMetricsProc.getAttributeFromLogRecord(logRecord, "content_type")
 	if err != nil {
-		sloMetricsProc.logger.Debug("content_type attribute missing/empty from log record",
-			zap.Any("attributes", logRecord.Attributes().AsRaw()),
-		)
 		return "http"
 	}
 
@@ -289,7 +286,9 @@ func (sloMetricsProc *sloMetricsProcessor) extractEndpoint(logRecord plog.LogRec
 func (sloMetricsProc *sloMetricsProcessor) getAttributeFromLogRecord(logRecord plog.LogRecord, attribute string) (string, error) {
 	attrVal, exists := logRecord.Attributes().Get(attribute)
 	if !exists || attrVal.Str() == "" || attrVal.Str() == "-" {
-		sloMetricsProc.logger.Warn(attribute + " attribute missing or empty from log record")
+		sloMetricsProc.logger.Debug(attribute+" attribute missing or empty from log record",
+			zap.Any("attributes", logRecord.Attributes().AsRaw()),
+		)
 		return "", fmt.Errorf(attribute + " attribute missing or empty from log record")
 	}
 	return attrVal.Str(), nil

--- a/slometricsemitter/log_processor_test.go
+++ b/slometricsemitter/log_processor_test.go
@@ -266,7 +266,6 @@ func floatToStr(f float64) string {
 	return fmt.Sprintf("%.3f", f)
 }
 
-// TestEndpointTypeDetection tests the determineEndpointType function
 func TestEndpointTypeDetection(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -278,20 +277,30 @@ func TestEndpointTypeDetection(t *testing.T) {
 			name:         "HTTP content type",
 			contentType:  "application/json",
 			expectedType: "http",
+			shouldError:  false,
+		},
+		{
+			name:         "HTTP content type with charset",
+			contentType:  "application/json; charset=utf-8",
+			expectedType: "http",
+			shouldError:  false,
 		},
 		{
 			name:         "GRPC content type",
 			contentType:  "application/grpc",
 			expectedType: "grpc",
+			shouldError:  false,
 		},
 		{
 			name:         "RPC2 content type",
 			contentType:  "application/rpc2",
 			expectedType: "rpc2",
+			shouldError:  false,
 		},
 		{
 			name:         "Missing content type",
 			expectedType: "http",
+			shouldError:  true,
 		},
 	}
 
@@ -304,7 +313,11 @@ func TestEndpointTypeDetection(t *testing.T) {
 				lr.Attributes().PutStr("content_type", tc.contentType)
 			}
 
-			endpointType := proc.determineEndpointType(lr)
+			endpointType, err := proc.determineEndpointType(lr)
+			if tc.shouldError {
+				require.Error(t, err)
+				return
+			}
 			assert.Equal(t, tc.expectedType, endpointType)
 		})
 	}

--- a/slometricsemitter/log_processor_test.go
+++ b/slometricsemitter/log_processor_test.go
@@ -294,12 +294,12 @@ func TestEndpointTypeDetection(t *testing.T) {
 		},
 		{
 			name:         "Missing content type",
-			contentType:  "-",
-			expectedType: "unknown",
+			expectedType: "http",
 		},
 		{
-			name:         "Missing content type",
-			expectedType: "unknown",
+			name:         "Unknown content type",
+			contentType:  "unknown/content-type",
+			expectedType: "http",
 		},
 	}
 
@@ -343,14 +343,6 @@ func TestEndpointExtraction(t *testing.T) {
 			expectedPath: "/service/method",
 		},
 		{
-			name:         "Valid unknown endpoint type with endpoint",
-			endpointType: "unknown",
-			attributes: map[string]string{
-				"x_affirm_endpoint_name": "/some/unexpected/endpoint",
-			},
-			expectedPath: "/some/unexpected/endpoint",
-		},
-		{
 			name:         "Invalid gRPC path format",
 			endpointType: "grpc",
 			attributes: map[string]string{
@@ -368,7 +360,7 @@ func TestEndpointExtraction(t *testing.T) {
 		},
 		{
 			name:         "Unknown endpoint type",
-			endpointType: "unknown",
+			endpointType: "unexpected",
 			shouldError:  true,
 		},
 	}


### PR DESCRIPTION
- Add health check extension to custom base otel collector build (it's used in our k8s deployment)
- Build amd64 binary for running on k8s nodes (the vast majority of our apps/infra run on linux amd64)
- Fixes processor code to handle live data in stage: response_code instead of status_code, endpoint type handling
- Added debug logs for easier debugging of live incoming log records